### PR TITLE
JWT update

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,10 @@
+# Contributors
+
+We are very happy to receive any pull requests for interesting API use cases or scripts, or documentation improvements.
+
+All contributors will be acknowledged here:
+
+* Richard Adams
+* Matthias Kowalski
+* Karolis Greblikas
+* Juozas Norkus

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,9 +1,0 @@
-h3. Contributors
-
-We are very happy to receive any pull requests for interesting API use cases or scripts, or documentation improvements.
-
-All contributors will be acknowledged here:
-
-* Richard Adams
-* Matthias Kowalski
-* Karolis Greblikas

--- a/Cookbook/Create-RSpaceDocument-from-a-text-file.md
+++ b/Cookbook/Create-RSpaceDocument-from-a-text-file.md
@@ -1,9 +1,11 @@
-# Aim
+# Create RSpace document from a text file
+
+## Aim
 
 You have some text files and you'd like to create RSpace documents with the content added in.
 These files could be plain .txt files or Wiki or Markdown syntax files, for example.
 
-# Background
+## Background
 
 Uploading files to RSpace is straightforward using the `files/` API. These files
 remain as attachments, though, which might not always be what you want if you want
@@ -16,39 +18,42 @@ Note that this recipe won't work for binary files such as MSOffice files.
 
 It has been developed on a standard Bash shell and tested on MacOS and Ubuntu Linux.
 
-# Software required
+## Software required
 
 You'll need `curl` and `jq`; both are readily available from package managers.
 
-# Recipe
-    ## step 1
-    for file in myfiles*.txt; do
-      echo "uploading $file  to $RSPACE_URL ..."
-      
-      ## step 2
-      filename=$(basename $file)
-      
-      ## step 3
-      value=`cat $file`
-      
-      ## step 4
-      jq -n --arg fieldContent "$value" --arg f "$filename" --arg targetFolder "$targetFolderId"\
-      '{name: $f, tags: "API,example", parentFolderId: $targetFolder, fields: [ {content: $fieldContent}]}'\
-      > content-tmp.txt
-      
-      ## step 5
-      sed -e 's:\\n:<br/>:g' < content-tmp.txt > content-with-html-newlines.txt
-      
-      ## step 6
-      curl -X POST -H "content-type: application/json" -H "apiKey:$API_KEY"\ 
-       -d @content-with-html-newlines.txt "$RSPACE_URL/documents"
-      
-      ## step 7
-      rm content-tmp.txt
-      rm content-with-html-newlines.txt
-    done
-    
-# Explanation
+## Recipe
+
+```bash
+## step 1
+for file in myfiles*.txt; do
+  echo "uploading $file  to $RSPACE_URL ..."
+  
+  ## step 2
+  filename=$(basename $file)
+  
+  ## step 3
+  value=`cat $file`
+  
+  ## step 4
+  jq -n --arg fieldContent "$value" --arg f "$filename" --arg targetFolder "$targetFolderId" \
+  '{name: $f, tags: "API,example", parentFolderId: $targetFolder, fields: [ {content: $fieldContent}]}'\
+  > content-tmp.txt
+  
+  ## step 5
+  sed -e 's:\\n:<br/>:g' < content-tmp.txt > content-with-html-newlines.txt
+  
+  ## step 6
+  curl -X POST -H "content-type: application/json" -H "apiKey:$API_KEY" \
+  -d @content-with-html-newlines.txt "$RSPACE_URL/documents"
+  
+  ## step 7
+  rm content-tmp.txt
+  rm content-with-html-newlines.txt
+done
+```
+
+## Explanation
 
 Most of the work here is preparing the content to be posted to the `/documents POST` endpoint.
 
@@ -62,7 +67,7 @@ This script:
 6. Now we can finally post the content to RSpace! Note the use of the `-d @content-with-html-newlines.txt` in the curl command, which takes the JSON from a file.
 7. Here we tidy up and remove temporary files.
 
-# Conclusion
+## Conclusion
 
 You now have a native RSpace document that can easily be edited, printed, shared or exported, just as if you had created it manually in the text editor.
 

--- a/Cookbook/Create-RSpaceDocument-from-a-text-file.sh
+++ b/Cookbook/Create-RSpaceDocument-from-a-text-file.sh
@@ -1,29 +1,30 @@
  #!/bin/bash
  
-    RSPACE_URL="my url for RSpace/api/v1"
-    API_KEY="set this key"
-    targetFolderId="a folder id to put document in"
-    ## step 1
-    for file in *.txt; do
-      echo "uploading $file  to $RSPACE_URL ..."
-      
-      ## step 2
-      filename=$(basename $file)
-      
-      ## step 3
-      value=`cat $file`
-      
-      ## step 4
-      jq -n --arg fieldContent "$value" --arg f "$filename" --arg targetFolder "$targetFolderId"\
-      '{name: $f, tags: "API,example", parentFolderId: $targetFolder, fields: [ {content: $fieldContent}]}' > content-tmp.txt
-      
-      ## step 5     
-      sed -i -e 's:\\n:<br/>:g' content-tmp.txt
-      
-      ## step 6
-      curl -X POST -H "content-type: application/json" -H "apiKey:$API_KEY" -d @content-tmp.txt "$RSPACE_URL/documents"
-      
-      ## step 7
-      rm content-tmp.txt
-      rm content-with-html-newlines.txt
-    done
+RSPACE_URL="my url for RSpace/api/v1"
+API_KEY="set this key"
+targetFolderId="a folder id to put document in"
+
+## step 1
+for file in *.txt; do
+  echo "uploading $file  to $RSPACE_URL ..."
+  
+  ## step 2
+  filename=$(basename $file)
+  
+  ## step 3
+  value=`cat $file`
+  
+  ## step 4
+  jq -n --arg fieldContent "$value" --arg f "$filename" --arg targetFolder "$targetFolderId"\
+  '{name: $f, tags: "API,example", parentFolderId: $targetFolder, fields: [ {content: $fieldContent}]}' > content-tmp.txt
+  
+  ## step 5     
+  sed -i -e 's:\\n:<br/>:g' content-tmp.txt
+  
+  ## step 6
+  curl -X POST -H "content-type: application/json" -H "apiKey:$API_KEY" -d @content-tmp.txt "$RSPACE_URL/documents"
+  
+  ## step 7
+  rm content-tmp.txt
+  rm content-with-html-newlines.txt
+done

--- a/Cookbook/README.md
+++ b/Cookbook/README.md
@@ -1,9 +1,13 @@
+# Cookbook
+
 This folder contains some examples for accomplishing specific tasks with RSpace API.
 
 All the examples will use placeholders for your API key and RSpace URL.
 On a Bash shell, you can set these as environment variables, for example:
 
-    export API_KEY=mysecretkey
-    export RSPACE_URL=https://myresearchspace.com/api/v1
-    
+```bash
+export API_KEY=mysecretkey
+export RSPACE_URL=https://REPLACE.researchspace.com/api/v1
+```
+
 So if you have an account on RSpace Community, RSPACE_URL should be `https://community.researchspace.com/api/v1`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# api-tutorial
+# API Tutorial
 
 ## Introduction
 
@@ -6,9 +6,9 @@ This project provides an introduction to using the RSpace API.
 
 ### Who is this tutorial for?
 
-For software developers, or scientists with programming or scripting skills, to learn how to use the
-RSpace API to interact programmatically with the RSpace Electronic Lab Notebook.
-All the examples can be run using a personal API token. 
+This tutorial is intended for software developers, or scientists with programming skills,
+to learn how to use the RSpace API to interact programmatically with the RSpace Electronic Lab Notebook.
+All the examples can be run using a personal API token.
 
 ### How does this tutorial fit in with other RSpace API documentation?
 
@@ -17,7 +17,7 @@ All the examples can be run using a personal API token.
 * The [API technical reference](https://community.researchspace.com/public/apiDocs)
   describes low-level technical details of the API endpoints
   and API contracts.
-* [Example code projects](https://github.com/rspace-os) provide language-specific API client example code. 
+* [Example code projects](https://github.com/rspace-os) provide language-specific API client example code.
 
 ### What version of RSpace is required for this tutorial?
 
@@ -31,48 +31,57 @@ For development purposes we have a Dockerised version of RSpace which lets you t
 
 ### Can I contribute to this documentation?
 
-Yes, please submit either pull requests, or emails to supportATresearchspaceDOTcom, with improvements or suggestions. We will happily add you to our list of [contributors](Contributors.md).
+Yes, please submit either pull requests, or emails to supportATresearchspaceDOTcom, with improvements or suggestions. We will happily add you to our list of [contributors](Contributing.md).
 
 ### Use-cases for the API
 
- * Uploading files from instruments or your device into RSpace automatically.
- * Creating RSpace documents and linking to files.
- * Adding or editing content in an RSpace document.
- * Searching and retrieving files and documents
- * Creating folders and notebooks for organising content.
- * Creating and publishing forms
- * Sharing RSpace documents
- * Importing MSWord or OpenOffice documents into RSpace
- * Scheduled exports of your work.
- * Creation of user accounts and groups (admins only)
- 
+* Uploading files from instruments or your device into RSpace automatically.
+* Creating RSpace documents and linking to files.
+* Adding or editing content in an RSpace document.
+* Searching and retrieving files and documents
+* Creating folders and notebooks for organising content.
+* Creating and publishing forms
+* Sharing RSpace documents
+* Importing MSWord or OpenOffice documents into RSpace
+* Scheduled exports of your work.
+* Creation of user accounts and groups (admins only)
+
 ### Getting started
+
 * Follow the instructions in the [RSpace help documentation](http://www.researchspace.com/help-and-support-resources/rspace-api-introduction/)
   to get set up with an API key for your account.
 * This tutorial will use `curl` commands to make API calls rather than assume a particular programming language.
 
 Code examples are shown in the following syntax:
 
-    curl -v -H "accept: application/json" -H "apiKey:$APIKEY"  "$RSPACE_URL/api/v1/files"
-    
- * The `-v` option to curl shows verbose information about the request to help you debug any problems.
- * You generally need to supply the content type to be accepted, and your API key, as request headers. 
- Replace '$APIKEY' with your own key. You can export this as an environment variable. This is good practice, as it avoids putting secret information on the command line e.g. in Bash shell:
- 
-     export API_KEY=mysecretkey
-     
- * Replace $RSPACE_URL with the base URL of your RSpace installation. E.g. if you're using RSpace Community, this would be `https://community.researchspace.com`. You can export this as an environment variable as well, e.g. in Bash shell:
- 
-     export RSPACE_URL=https://community.researchspace.com
-     
- * Any other text in <ANGLE_BRACKETS> is a placeholder for a value specific to your account, e.g. a resource identifier. 
- 
- * You can check your setup by making a simple call to the `/status` endpoint:
- 
-     curl -H "apiKey:$APIKEY" "$RSPACE_URL/api/v1/status"
-   
+```bash
+curl -v -H "accept: application/json" -H "apiKey:$APIKEY" "$RSPACE_URL/api/v1/files"
+```
+
+* The `-v` option to curl shows verbose information about the request to help you debug any problems.
+* You generally need to supply the content type to be accepted, and your API key, as request headers.
+Replace `$APIKEY` with your own key. You can export this as an environment variable. This is good practice, as it avoids putting secret information on the command line, e.g. in Bash shell:
+
+```bash
+export API_KEY=mysecretkey
+```
+
+Please note that Bash will save this into `.bash_history` file in the home directory. It is possible to disable the logging of `export` statements.
+
+* Replace $RSPACE_URL with the base URL of your RSpace installation. E.g. if you're using RSpace Community, this would be `https://community.researchspace.com`. You can export this as an environment variable as well, e.g. in Bash shell:
+
+```bash
+export RSPACE_URL=https://community.researchspace.com
+```
+
+* Any other text in <ANGLE_BRACKETS> is a placeholder for a value specific to your account, e.g. a resource identifier.
+* You can check your setup by making a simple call to the `/status` endpoint:
+
+```bash
+curl -H "apiKey:$APIKEY" "$RSPACE_URL/api/v1/status"
+```
+
 All code snippets are provided as working examples in the `tutorial-data` folders in this project.
- 
 
 ## Creating content
 
@@ -81,147 +90,173 @@ All code snippets are provided as working examples in the `tutorial-data` folder
 Being able to upload a file to RSpace automatically can save you a lot of time and effort compared to manually uploading files
 using the web application. You can perform tasks such as:
 
- * Bulk upload of files
- * Scheduled upload of files, e.g. files generated by an instrument, sequence  files, image files etc
+* Bulk upload of files
+* Scheduled upload of files, e.g. files generated by an instrument, sequence  files, image files etc
 
 The simplest way to upload a file is as follows:
 
-    curl -v  -X POST -H "accept: application/json" -H "apiKey: $APIKEY" \
-    -H "content-type: multipart/form-data" -F "file=@<MY_FILE.txt>" \
-     "$RSPACE_URL/api/v1/files"
-     
-This will upload a file '<MY_FILE.txt>'  a  default folder called 'Api Inbox' in the relevant section
- of the Gallery. This folder will be automatically created for you if it doesn't yet exist. JSON will be returned:
+```bash
+curl -v  -X POST -H "accept: application/json" -H "apiKey: $APIKEY" \
+-H "content-type: multipart/form-data" -F "file=@<MY_FILE.txt>" \
+"$RSPACE_URL/api/v1/files"
+```
 
-    {
-      "id" : 728,
-      "globalId" : "GL728",
-      "name" : "<MY_FILE.txt>",
-      "caption" : "",
-      "contentType" : "text/plain",
-      "created" : "2017-07-23T09:54:16.007Z",
-      "size" : 2812,
-      "version" : 1
-      "_links" : [ {
-         "link" : "$RSPACE_URL/api/v1/files/728",
-         "rel" : "self"
-       }, {
-         "link" : "$RSPACE_URL/api/v1/files/728/file",
-         "rel" : "enclosure"
-      } ]
-    }
-    
- The `_links` property contains pre-generated links to resources created or referenced in API calls. In this case, the 'self'
-  link will return the file metadata, and the 'enclosure' link will download the file contents. These will be described later.
-    
- You can also upload a file with an optional caption, and also specify a folder to put the file in.
- 
-     curl -v  -X POST -H "accept: application/json" -H "apiKey: $APIKEY" \
-     -H "content-type: multipart/form-data" -F "file=@<MY_FILE.txt>" -F"folderId=<FOLDER_ID>\
-     -F "caption=some metadata about this file" \"$RSPACE_URL/api/v1/files"
-     
- The caption will appear in the 'Info' section of each Gallery item, and just like a manually edited caption, will be searchable.
- This is a good way to add some descriptive metadata to your file so that you can locate it easily.
- 
- Browsing folders via the API is not yet supported. However it's very easy to get a folder ID from RSpace by clicking
-  on the 'info' icon beside a Gallery folder.
- 
- **Note:** There are some restrictions on which folders you can upload to. For example, if uploading image files, a folder ID must
-  be either the Gallery Images folder, or a subfolder of the images folder. You can't upload a file directly into a workspace folder
-   or notebook.
-   
- If you're uploading many files of mixed type, then it's probably safer not to specify a single folder, but to let them be 
- placed in the relevant `API Inbox` folder where you can organise them later.
- 
-#### Uploading files from a folder.
- 
- The script [batchUpload.sh](tutorial-data/uploading-a-file-1/batchUpload.sh) will upload files sequentially from a list
- on the command line, e.g.
- 
-     # upload a single file
-     ./batchUpload.sh myFile.txt
-     # upload all png files in folder
-     ./batchUpload.sh `ls *.png`
-     
+This will upload a file '<MY_FILE.txt>'  a  default folder called 'Api Inbox' in the relevant section
+of the Gallery. This folder will be automatically created for you if it doesn't yet exist. JSON will be returned:
+
+```json
+{
+  "id" : 728,
+  "globalId" : "GL728",
+  "name" : "<MY_FILE.txt>",
+  "caption" : "",
+  "contentType" : "text/plain",
+  "created" : "2017-07-23T09:54:16.007Z",
+  "size" : 2812,
+  "version" : 1
+  "_links" : [ {
+     "link" : "$RSPACE_URL/api/v1/files/728",
+     "rel" : "self"
+   }, {
+     "link" : "$RSPACE_URL/api/v1/files/728/file",
+     "rel" : "enclosure"
+  } ]
+}
+```
+
+The `_links` property contains pre-generated links to resources created or referenced in API calls. In this case, the 'self'
+link will return the file metadata, and the 'enclosure' link will download the file contents. These will be described later.
+
+You can also upload a file with an optional caption, and also specify a folder to put the file in.
+
+```bash
+curl -v  -X POST -H "accept: application/json" -H "apiKey: $APIKEY" \
+-H "content-type: multipart/form-data" -F "file=@<MY_FILE.txt>" -F"folderId=<FOLDER_ID>\
+-F "caption=some metadata about this file" \"$RSPACE_URL/api/v1/files"
+```
+
+The caption will appear in the 'Info' section of each Gallery item, and just like a manually edited caption, will be searchable.
+This is a good way to add some descriptive metadata to your file so that you can locate it easily.
+
+Browsing folders via the API is not yet supported. However it's very easy to get a folder ID from RSpace by clicking
+on the 'info' icon beside a Gallery folder.
+
+**Note:** There are some restrictions on which folders you can upload to. For example, if uploading image files, a folder ID must
+be either the Gallery Images folder, or a subfolder of the images folder. You can't upload a file directly into a workspace folder
+or notebook.
+
+If you're uploading many files of mixed type, then it's probably safer not to specify a single folder, but to let them be
+placed in the relevant `API Inbox` folder where you can organise them later.
+
+#### Uploading files from a folder
+
+The script [batchUpload.sh](tutorial-data/uploading-a-file-1/batchUpload.sh) will upload files sequentially from a list
+on the command line, e.g.
+
+```bash
+# upload a single file
+./batchUpload.sh myFile.txt
+# upload all png files in folder
+./batchUpload.sh `ls *.png`
+```
+
 #### Replacing files
 
 You can replace the file contents of a file by uploading a new version, using the ID obtained from an initial upload.
 
-    curl -v -X POST -H "accept: application/json" -H "apiKey: $APIKEY" \
-    -H "content-type: multipart/form-data" -F "file=@<MY_FILE.txt>" \
-     "$RSPACE_URL/api/v1/files/<FILE_ID>file"
-     
+```bash
+curl -v -X POST -H "accept: application/json" -H "apiKey: $APIKEY" \
+-H "content-type: multipart/form-data" -F "file=@<MY_FILE.txt>" \
+"$RSPACE_URL/api/v1/files/<FILE_ID>file"
+```
+
 This will also return a JSON response of the uploaded File, with updated `version` property. The `id` will remain the same.
-     
+
 ### Downloading files
 
 You can download files from RSpace to your device using the following syntax:
 
-    curl -v  -H "accept:application/octet-stream" -H "apiKey:$APIKEY" "$RSPACE_URL/api/v1/files/<FILE_ID>/file"
- 
+```bash
+curl -v  -H "accept:application/octet-stream" -H "apiKey:$APIKEY" "$RSPACE_URL/api/v1/files/<FILE_ID>/file"
+```
+
 ### Creating documents
 
 You can create documents of different types, and add content to some or all of the fields.
 Some of the examples use JSON request bodies - files of JSON data are in  [this project](tutorial-data/creatingDocument).
 
-#### Creating a basic document.
+#### Creating a basic document
 
 This is the simplest way to create a document - it will be a 'Basic Document' (a single text field) with default name 'Untitled Document' and
- no content. Note that an empty request body '-d {}' is required.
- 
-    curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" -d {} "$RSPACE_URL/api/v1/documents"
-    
+no content. Note that an empty request body '-d {}' is required.
+
+```bash
+curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" -d {} "$RSPACE_URL/api/v1/documents"
+```
+
 This example is a little more useful - creating a named, tagged Basic Document with some content:
 
-    curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" \
-       -d "@tutorial-data/creatingDocument/basicDocument-named-withContent.json" \
-       "$RSPACE_URL/api/v1/documents"
+```bash
+curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" \
+-d "@tutorial-data/creatingDocument/basicDocument-named-withContent.json" \
+"$RSPACE_URL/api/v1/documents"
+```
 
 You can also set the parent folder that you want the document created in. This should be folder in your Workspace - not a shared folder.
 
-    curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" \
-       -d "@tutorial-data/creatingDocument/basicDocument-named-withContent-withParentFolder.json" \
-       "$RSPACE_URL/api/v1/documents"
+```bash
+curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" \
+-d "@tutorial-data/creatingDocument/basicDocument-named-withContent-withParentFolder.json" \
+"$RSPACE_URL/api/v1/documents"
+```
 
 If you don't set parent folder, it will appear in the 'API Inbox' folder by default.
-       
+
 #### Creating links in documents to files
 
 If you want to create links to files in a document's content, you can easily do this by adding a tag with the syntax:
 
-    <fileId=1234>
-    
-  to your document content, e.g. replacing '1234' with the id of your file. RSpace will then create links in exactly the same way
-  as it does in the UI. E.g.
-    
-    {
-      "name": "My Experiment",
-      "tags": "API,example",
-      "fields": [
-         {
-           "content": "Protocol as described in <fileId=1234>, except using EDTA 3uM. "
-         }
-        ]
-    }
+```json
+<fileId=1234>
+```
+
+to your document content, e.g. replacing '1234' with the id of your file. RSpace will then create links in exactly the same way
+as it does in the UI. E.g.
+
+```json
+{
+  "name": "My Experiment",
+  "tags": "API,example",
+  "fields": [
+     {
+       "content": "Protocol as described in <fileId=1234>, except using EDTA 3uM. "
+     }
+    ]
+}
+```
 
 ### Creating notebooks and folders
 
 You can create notebooks and folders:
 
-    curl -X POST "$RSPACE_URL/api/v1/folders" -H "accept: application/json" -H "apiKey: $APIKEY" \
-    -H "content-type: application/json" \
-    -d "{ \"name\": \"My notebook\", \"notebook\": \"true\"}"
-    
-will create a new Notebook in your Home folder. If you prefer to create a folder just set the notebook parameter to 'false'. Or,just omit the parameter - the default behaviour is to create a folder.
+```bash
+curl -X POST "$RSPACE_URL/api/v1/folders" -H "accept: application/json" -H "apiKey: $APIKEY" \
+-H "content-type: application/json" \
+-d "{ \"name\": \"My notebook\", \"notebook\": \"true\"}"
+```
+
+will create a new Notebook in your Home folder. If you prefer to create a folder just set the notebook parameter to 'false'. Or, just omit the parameter - the default behaviour is to create a folder.
 
 You can also create a new folder or notebook in an existing folder using the `parentFolderId` parameter, e.g.
 
-    curl -X POST "$RSPACE_URL/api/v1/folders" -H "accept: application/json" -H "apiKey: $APIKEY" \
-     -H "content-type: application/json"\
-     -d "{ \"name\": \"My notebook\", \"parentFolderId\":\"12234\"}"
-    
+```bash
+curl -X POST "$RSPACE_URL/api/v1/folders" -H "accept: application/json" -H "apiKey: $APIKEY" \
+-H "content-type: application/json"\
+-d "{ \"name\": \"My notebook\", \"parentFolderId\":\"12234\"}"
+```
+
 There are some restrictions on where you can create folders and notebooks, which are required to  maintain consistent behaviour
- with the web application. 
+with the web application.
 
 * You can't create folders or notebooks inside notebooks
 * You can't create notebooks inside the Shared Folder; create them in a User folder first, then share. (Sharing is not yet supported in the API, but you can do this in the web application).
@@ -234,136 +269,161 @@ returning a `409 Conflict` error code.
 
 You just include in the request body the data that you want to change - any/all of name, tags and field content.
 
-    curl -v  -X PUT -H "content-type: application/json" -H "apiKey: $APIKEY"\
-      -d "@tutorial-data/editingDocument/editBasicDocument.json"  "$RSPACE_URL/api/v1/documents/<DOC_ID>"
-      
-### Creating and editing multi-field documents.
+```bash
+curl -v  -X PUT -H "content-type: application/json" -H "apiKey: $APIKEY"\
+-d "@tutorial-data/editingDocument/editBasicDocument.json"  "$RSPACE_URL/api/v1/documents/<DOC_ID>"
+```
 
-Now we know how to  create simple documents, let's consider multi-field of 'Structured Documents' that contain 
- fields of different types as defined by a Form. You can add/edit content to any or all of the fields.
- 
+### Creating and editing multi-field documents
+
+Now we know how to  create simple documents, let's consider multi-field of 'Structured Documents' that contain
+fields of different types as defined by a Form. You can add/edit content to any or all of the fields.
+
 In this section we'll be using the standard 'Experiment' form that is already defined for you in RSpace. It contains
- 7 text fields: Method, Objective, Procedure, Results, Discussion, Conclusion, Comment.
- 
- You'll need to get the ID of the form from the UI, and include this ID as in the  'form' property in the request body.
- When adding content, the order is important. If for example, you just want to add content to the 'Procedure' field,
-  which is the 3rd field, then supply a list of 7 fields, of which only the 3rd has some data, e.g.
-  
-    curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" \
-      -d "@tutorial-data/creatingDocument/complexDocument-named-withContent.json" "$RSPACE_URL/api/v1/documents"
- 
- When editing content, there are two options. Either you can send the data as a list of all fields, as for POST, including content
-  as necessary, or you can reference a field by its ID, and just send values for 
-  [those specific fields](tutorial-data/editingDocument/editComplexDocument-named-withFieldIds.json).
-  
-    curl -v  -X PUT -H "content-type: application/json" -H "apiKey: $APIKEY"\
-      -d "@tutorial-data/editingDocument/editComplexDocument-named-withFieldIds.json"\
-      "$RSPACE_URL/api/v1/documents/<DOC_ID>"
-      
- As for BasicDocuments, you can also edit name and tags in the request body as well.
- 
+7 text fields: Method, Objective, Procedure, Results, Discussion, Conclusion, Comment.
+
+You'll need to get the ID of the form from the UI, and include this ID as in the  'form' property in the request body.
+When adding content, the order is important. If for example, you just want to add content to the 'Procedure' field,
+which is the 3rd field, then supply a list of 7 fields, of which only the 3rd has some data, e.g.
+
+```bash
+curl -X POST -H "content-type: application/json" -H "apiKey:$APIKEY" \
+-d "@tutorial-data/creatingDocument/complexDocument-named-withContent.json" "$RSPACE_URL/api/v1/documents"
+```
+
+When editing content, there are two options. Either you can send the data as a list of all fields, as for POST, including content
+as necessary, or you can reference a field by its ID, and just send values for
+[those specific fields](tutorial-data/editingDocument/editComplexDocument-named-withFieldIds.json).
+
+```bash
+curl -v  -X PUT -H "content-type: application/json" -H "apiKey: $APIKEY"\
+-d "@tutorial-data/editingDocument/editComplexDocument-named-withFieldIds.json"\
+"$RSPACE_URL/api/v1/documents/<DOC_ID>"
+```
+
+As for BasicDocuments, you can also edit name and tags in the request body as well.
+
 ## Navigating content
 
 You can navigate the folder tree in an analogous way to using the 'Tree View' in the workspace UI. You can start at the Home folder:
 
-    curl -v -H"apiKey: $APIKEY" "$RSPACE_URL/api/v1/folders/tree"
-    
+```bash
+curl -v -H"apiKey: $APIKEY" "$RSPACE_URL/api/v1/folders/tree"
+```
+
 or at a specific folder by specifying its ID:
 
-    curl -v -H"apiKey: $APIKEY" "$RSPACE_URL"/api/v1/folders/tree/<FOLDER_ID>"
-    
+```bash
+curl -v -H"apiKey: $APIKEY" "$RSPACE_URL"/api/v1/folders/tree/<FOLDER_ID>"
+```
+
 Both the above requests will return a paginated list of basic information about each item in the folder:
-    
-    "totalHits": 7,
-    "pageNumber": 0,
-    "_links": [
-      {
-       "link": "https://rspac1918-foldertree-api-7.researchspace.com/api/v1/folders/tree?pageNumber=0",
-       "rel": "self"
-      }
-      ],
-    "parentId": 162,
-    "records": [
-      "id": 185,
-      "globalId": "GL185",
-      "name": "ethane.jpg",
-      "created": "2019-09-26T08:22:53.434Z",
-      "lastModified": "2019-09-26T08:22:53.434Z",
-      "parentFolderId": 163,
-      "type": "MEDIA",
-      "_links": [
-        {
-          "link": "https://rspac1918-foldertree-api-7.researchspace.com/api/v1/files/185",
-          "rel": "self"
-        }
-        .......
-      ]
-      
- Note that in the above data:
- 
- * the `type` field is one of 'MEDIA', 'DOCUMENT', 'NOTEBOOK' or 'FOLDER'. Use this to identify the type of returned item.
- * Use the `self` link to get more information about the individual item
- * `parentId` is the parent of the listed folder. You can use this to navigate up the folder tree. If the listing is of the Home folder, `parentId` will not be set
-    
+
+```json
+"totalHits": 7,
+"pageNumber": 0,
+"_links": [
+  {
+   "link": "https://rspac1918-foldertree-api-7.researchspace.com/api/v1/folders/tree?pageNumber=0",
+   "rel": "self"
+  }
+  ],
+"parentId": 162,
+"records": [
+  "id": 185,
+  "globalId": "GL185",
+  "name": "ethane.jpg",
+  "created": "2019-09-26T08:22:53.434Z",
+  "lastModified": "2019-09-26T08:22:53.434Z",
+  "parentFolderId": 163,
+  "type": "MEDIA",
+  "_links": [
+    {
+      "link": "https://rspac1918-foldertree-api-7.researchspace.com/api/v1/files/185",
+      "rel": "self"
+    }
+    .......
+  ]
+```
+
+Note that in the above data:
+
+* the `type` field is one of 'MEDIA', 'DOCUMENT', 'NOTEBOOK' or 'FOLDER'. Use this to identify the type of returned item.
+* Use the `self` link to get more information about the individual item
+* `parentId` is the parent of the listed folder. You can use this to navigate up the folder tree. If the listing is of the Home folder, `parentId` will not be set
+
 Additionally you can restrict the results to one or any of 'document', 'folder' or 'notebook':
 
-    curl -v  -H"apiKey: $APIKEY" \
-    "$RSPACE_URL/api/v1/folders/tree?typesToInclude=folder,notebook&pageSize=20"
-    
- will return just folders and notebooks from the Home folder, paginated 20 at a time. 
+```bash
+curl -v  -H"apiKey: $APIKEY" \
+"$RSPACE_URL/api/v1/folders/tree?typesToInclude=folder,notebook&pageSize=20"
+```
+
+will return just folders and notebooks from the Home folder, paginated 20 at a time.
 
 ## Deleting content
- 
- You can mark documents  as deleted. This behaves in the same way as the web UI - documents are not completely removed
-  but are merely hidden from listings and search results. This is a simple call that takes single path variable, the ID
-  of the document to delete:
-  
-    curl -v  -X DELETE  -H "apiKey: $APIKEY"\
-      "$RSPACE_URL/api/v1/documents/<DOC_ID>"
-      
+
+You can mark documents  as deleted. This behaves in the same way as the web UI - documents are not completely removed
+but are merely hidden from listings and search results. This is a simple call that takes single path variable, the ID
+of the document to delete:
+
+```bash
+curl -v  -X DELETE  -H "apiKey: $APIKEY"\
+"$RSPACE_URL/api/v1/documents/<DOC_ID>"
+```
+
 and in a similar way you can delete whole notebooks or folders as well:
 
-    curl -v  -X DELETE  -H "apiKey: $APIKEY"\
-      "$RSPACE_URL/api/v1/folders/<FOLDER_ID>"
-      
+```bash
+curl -v  -X DELETE  -H "apiKey: $APIKEY"\
+"$RSPACE_URL/api/v1/folders/<FOLDER_ID>"
+```
+
 In both these cases, if a notebook or document was previously shared, then they will be unshared as part of the deletion process.
-  
- 
+
 ## Forms
 
 ### Listing forms
 
-You can list and search for Forms. The search mechanism replicates what is used 
+You can list and search for Forms. The search mechanism replicates what is used
 in the 'Manage Forms' page in the web application.
 
 To list all Forms:
-      
-    curl -X GET "$RSPACE_URL/api/v1/forms" -H "accept: application/json" -H "apiKey: $APIKEY"
-    
+
+```bash
+curl -X GET "$RSPACE_URL/api/v1/forms" -H "accept: application/json" -H "apiKey: $APIKEY"
+```
+
 As for documents and files, you can order and paginate:
 
-    curl -X GET "$RSPACE_URL/api/v1/forms?pageSize=10&orderBy=lastModified%20desc" \
-       -H "accept: application/json" -H "apiKey: $APIKEY"
-       
+```bash
+curl -X GET "$RSPACE_URL/api/v1/forms?pageSize=10&orderBy=lastModified%20desc" \
+-H "accept: application/json" -H "apiKey: $APIKEY"
+```
+
 Searching is by freeform wildcard search for all or part of the `name` or `tag` property of the form.
 
-    curl -X GET "$RSPACE_URL/api/v1/forms?query=Algal%20Sample" \
-       -H "accept: application/json" -H "apiKey: $APIKEY"
-       
+```bash
+curl -X GET "$RSPACE_URL/api/v1/forms?query=Algal%20Sample" \
+-H "accept: application/json" -H "apiKey: $APIKEY"
+```
+
 The search results contain summary information about each form, but does not contain the list of Field definitions. If you want to get this information, then get a single Form by its ID, e.g.
 
-    curl -X GET "$RSPACE_URL/api/v1/forms/<ID>" \
-       -H "accept: application/json" -H "apiKey: $APIKEY"
-       
+```bash
+curl -X GET "$RSPACE_URL/api/v1/forms/<ID>" \
+-H "accept: application/json" -H "apiKey: $APIKEY"
+```
+
 Please see [Form Help documentation](https://www.researchspace.com/enterprise/help-and-support-resources-enterprise/forms-enterprise/) for more details on how Forms are versioned and used in RSpace. As in the user interface, form searching retrieves the *current version* of a Form.
 
-###  Creating new forms
+### Creating new forms
 
 You can create new forms through the API. Read more about this in [forms.md](forms.md)
 
 ## Exporting content
 
-You can programmatically export your work in HTML or XML format. This 
+You can programmatically export your work in HTML or XML format. This
 might be useful if you want to make scheduled backups, for example. If you're an admin or PI you can export
 a particular user's work if you have permission.
 
@@ -375,18 +435,22 @@ From RSpace 1.56, it is possible to import Microsoft Word or OpenOffice files as
 
 The API calls are similar to those for uploading files - you'll need a Word/Office file, and optionally a folder ID that you want to import into:
 
-    curl -X POST "$RSPACE_URL/api/v1/import/word" -H "accept: application/json" \
-    -H "apiKey: $APIKEY" -H "content-type: multipart/form-data" \
-     -F "file=@<WORD_FILE>.doc;type=application/msword"
-    
+```bash
+curl -X POST "$RSPACE_URL/api/v1/import/word" -H "accept: application/json" \
+-H "apiKey: $APIKEY" -H "content-type: multipart/form-data" \
+-F "file=@<WORD_FILE>.doc;type=application/msword"
+```
+
 If you don't specify a folder ID, the RSpace document will be created in the 'Api Inbox' folder.
 
 From RSpace 1.58, Evernote .enex files can be imported using a similar mechanism, e.g.:
 
-    curl -X POST "$RSPACE_URL/api/v1/import/evernote" -H "accept: application/json" \
-    -H "apiKey: $APIKEY" -H "content-type: multipart/form-data" \
-     -F "file=@<EVERNOT_FILE>.enex;type=application/xml"
-     
+```bash
+curl -X POST "$RSPACE_URL/api/v1/import/evernote" -H "accept: application/json" \
+-H "apiKey: $APIKEY" -H "content-type: multipart/form-data" \
+-F "file=@<EVERNOT_FILE>.enex;type=application/xml"
+```
+
 If successful, a new folder will be returned, containing the newly imported notes. An Evernote 'Note' will be converted into an RSpace plain text document.
 
 ## Sharing items with other groups and users

--- a/creating_accounts.md
+++ b/creating_accounts.md
@@ -1,3 +1,5 @@
+# Creating accounts
+
 From RSpace 1.59.3 (API version 1.5.4) you can programmatically create new user accounts and groups.
 Please note that:
 
@@ -6,30 +8,31 @@ Please note that:
 
 ## Background
 
-###  What accounts can be created
+### What accounts can be created
 
 * A sysadmin user can create users with any role, just like in the web interface
 
-###  How do I create groups?
+### How do I create groups?
 
 * Firstly ensure all users exist on the system - create new users if need be.
 * Then create a LabGroup, with a PI user
-
 
 ## Creating a user account
 
 Send a POST request to /sysadmin/users with the details of the user to be created in the request body. A request body is shown in [createUser.json](tutorial-data/accounts/createUser.json)
 
-     curl -v  -X POST -H "content-type: application/json" -H "apiKey: <APIKEY>"\
-      -d "@tutorial-data/accounts/createUser.json"\
-      "<RSPACE_URL>/api/v1/sysadmin/users"
-      
- There are some restrictions on the values of data fields passed, 
- 
- * All fields are mandatory unless indicated (see Swagger docs for details)
- * Usernames must be >= 6 characters
- * Passwords must be >= 8 characters
- 
+```bash
+curl -v  -X POST -H "content-type: application/json" -H "apiKey: <APIKEY>"\
+-d "@tutorial-data/accounts/createUser.json"\
+"<RSPACE_URL>/api/v1/sysadmin/users"
+```
+
+There are some restrictions on the values of data fields passed:
+
+* All fields are mandatory unless indicated (see Swagger docs for details)
+* Usernames must be >= 6 characters
+* Passwords must be >= 8 characters
+
 ## Creating a group
 
 In order to create a group, all users who are to be added to the group must already exist on the system.
@@ -38,22 +41,26 @@ Also, at least one member must have a global PI role and be assigned the role of
 
 Here is an example of a valid group post request body. All fields are required.
 
+```json
+{
+  "name": "MyGroup",
+  "members": [
     {
-     "name": "MyGroup",
-     "members": [
-       {
-         "username": "bob123",
-         "roleInGroup": "PI"
-       },
-       {
-         "username": "labmember",
-         "roleInGroup": "DEFAULT"
-       }
-     ]
+      "username": "bob123",
+      "roleInGroup": "PI"
+    },
+    {
+      "username": "labmember",
+      "roleInGroup": "DEFAULT"
     }
+  ]
+}
+```
 
-which creates a group with 2 members, a PI and a standard member. 
+which creates a group with 2 members, a PI and a standard member.
 
-    curl -v  -X POST -H "content-type: application/json" -H "apiKey: <APIKEY>"\
-      -d "@tutorial-data/accounts/createGroup.json"\
-      "<RSPACE_URL>/api/v1/sysadmin/groups"
+```bash
+curl -v  -X POST -H "content-type: application/json" -H "apiKey: <APIKEY>"\
+-d "@tutorial-data/accounts/createGroup.json"\
+"<RSPACE_URL>/api/v1/sysadmin/groups"
+```

--- a/forms.md
+++ b/forms.md
@@ -1,3 +1,5 @@
+# Forms
+
 From RSpace 1.50 (API version 1.4) you can programmatically create forms.
 
 ## Background
@@ -6,35 +8,39 @@ Before we start with the API calls it's instructive to look at how Forms are mod
 
 ![Export sequence](./tutorial-data/forms/form-lifecycle.png)
 
-In the UI, initially you create a form and add some fields to it. It is in the `NEW` state here as it has not 
- been used to create any documents. You can delete it at this stage, or make incremental edits to the field
- definitions.
- 
- In order to make the form available to create documents, you **publish** the form. This creates version 1 of the Form and documents can now be created using the form (once you've added it to the create menu). You can also share the form with your group, if you want your group to re-use your form.
- 
- If you make edits to the form now, RSpace will create a new version, and the previous version will become `OLD` and no longer be available for creating new documents.
- 
- If you want to make a form no longer usable for creating new documents, you can unpublish it.
- 
+In the UI, initially you create a form and add some fields to it. It is in the `NEW` state here as it has not
+been used to create any documents. You can delete it at this stage, or make incremental edits to the field
+definitions.
+
+In order to make the form available to create documents, you **publish** the form. This creates version 1 of the Form and documents can now be created using the form (once you've added it to the create menu). You can also share the form with your group, if you want your group to re-use your form.
+
+If you make edits to the form now, RSpace will create a new version, and the previous version will become `OLD` and no longer be available for creating new documents.
+
+If you want to make a form no longer usable for creating new documents, you can unpublish it.
+
 ## Forms in the API
 
 In the API we've simplified somewhat the interactions available in the UI. You create a form in one go, supplying all the Field definitions in a single `POST` request. You can then control publishing and sharing in subsequent operations.
 
 An example of a new form JSON to include in the request body is in the [tutorial-data](tutorial-data/forms/createNewForm.json)
 
-    curl -X POST -H "content-type: application/json" -H "apiKey:<APIKEY>" \
-      -d "@tutorial-data/forms/createNewForm.json" "<RSPACE_URL>/api/v1/forms"
-      
- The returned JSON will show that the newly created form is in the `NEW` state. From here you can publish  or share using simple `PUT` requests using the ID of the form.
- 
-    curl -X PUT -H "content-type: application/json" -H "apiKey:<APIKEY>" \
-      "<RSPACE_URL>/api/v1/forms/<ID>/publish"
-      
-     curl -X PUT -H "content-type: application/json" -H "apiKey:<APIKEY>" \
-      "<RSPACE_URL>/api/v1/forms/<ID>/share"
-      
+```bash
+curl -X POST -H "content-type: application/json" -H "apiKey:<APIKEY>" \
+-d "@tutorial-data/forms/createNewForm.json" "<RSPACE_URL>/api/v1/forms"
+```
+
+The returned JSON will show that the newly created form is in the `NEW` state. From here you can publish  or share using simple `PUT` requests using the ID of the form.
+
+```bash
+curl -X PUT -H "content-type: application/json" -H "apiKey:<APIKEY>" \
+"<RSPACE_URL>/api/v1/forms/<ID>/publish"
+  
+curl -X PUT -H "content-type: application/json" -H "apiKey:<APIKEY>" \
+"<RSPACE_URL>/api/v1/forms/<ID>/share"
+```
+
 Notice that the available actions are included in the _links  property. These actions require valid permissions, so if  you are not the owner of the Form then these actions will not be available.
-      
+
 The 'share' action is simplified - it will share the form with your group. Sharing with everyone is not permitted through the API.
 
 For end-users to use the forms, they'll have to add the form to their Create menu, as usual.
@@ -45,9 +51,9 @@ Forms in the `NEW` state, or forms that have been published, but not yet used to
 
 You can delete a form as follows:
 
-    curl -v  -X DELETE  -H "apiKey: <APIKEY>"\
-      "<RSPACE_URL>/api/v1/forms/<ID>"
+```bash
+curl -v  -X DELETE  -H "apiKey: <APIKEY>" \
+"<RSPACE_URL>/api/v1/forms/<ID>"
+```
 
 If a form cannot be deleted (perhaps because it has been used to create documents), a `422` status code will be returned.
-      
- 

--- a/jobs.md
+++ b/jobs.md
@@ -1,8 +1,10 @@
-From RSpace 1.47 (API version 1.3) you can programmatically export your work in HTML or XML format. This 
+# Jobs - exports
+
+From RSpace 1.47 (API version 1.3) you can programmatically export your work in HTML or XML format. This
 might be useful if you want to make scheduled backups, for example. If you're an admin or PI you can export
 a particular user's work if you have permission.
 
-Because export can be quite time-consuming, this is an _asynchronous_ operation. On initial export you will receive a link to 
+Because export can be quite time-consuming, this is an _asynchronous_ operation. On initial export you will receive a link to
 a **job** that you can query for progress updates. When the export has completed there will be a link to
 access the exported file - which may be very large.
 
@@ -10,32 +12,37 @@ The diagram below shows the process, along with the status codes at each step. W
 
 ![Export sequence](./tutorial-data/export/publicApiExport.png)
 
-### Initial submission
+## Initial submission
 
 The initial export call is a `POST` request to `export/{format}/{scope}` where `format` is one of 'html' or 'xml'
 and `scope` is 'user' or 'group'. You can optionally specify a user or group ID. If you don't you'll
 export your own work or your own group's work (group export is only available to  PIs). E.g. to export
 your own work in HTML:
 
-    curl -XPOST -v -H "apiKey: <APIKEY>"  "<RSPACE_URL>/api/v1/export/html/user/"
-    
- All being well, you'll receive a 202 Accepted response, job id and a link to a job to query subsequent progress:
- 
- 
-    {
-     "id": 23,
-     "status": "STARTING",
-     "_links": { [
-      "rel": "self",
-      "link": "https://myrspace.com/api/v1/jobs/23"
-      ] }
-     }
-     
- You can use this link to periodically assess progress:
- 
-     curl -v -H "apiKey: <APIKEY>"  "<RSPACE_URL>/api/v1/jobs/23"
- 
-Export may take a  few minutes, so we'd recommend checking for completion  no more frequently than once 
+```bash
+curl -XPOST -v -H "apiKey: <APIKEY>"  "<RSPACE_URL>/api/v1/export/html/user/"
+```
+
+All being well, you'll receive a 202 Accepted response, job id and a link to a job to query subsequent progress:
+
+```json
+{
+  "id": 23,
+  "status": "STARTING",
+  "_links": { [
+   "rel": "self",
+   "link": "https://REPLACE.researchspace.com/api/v1/jobs/23"
+   ] }
+}
+```
+
+You can use this link to periodically assess progress:
+
+```bash
+curl -v -H "apiKey: <APIKEY>" "<RSPACE_URL>/api/v1/jobs/23"
+```
+
+Export may take a  few minutes, so we'd recommend checking for completion  no more frequently than once
 per minute.
 
 There are 3 statuses that indicate termination:
@@ -50,21 +57,25 @@ All calls to `job/{id}` return a 200 response regardless of the state of the und
   
 If the job has completed you'll get additional information about the export process:
 
-     {
-      "id": 23,
-      "status": "COMPLETED",
-      "result": {
-        "checksum": "abcde12345",
-        "algorithm": "CRC32",
-        "size": 1024,
-        "expiryDate": "2017-11-25T00:00:00.000Z"
-       },
-      "_links": [{
-        "rel": "enclosure",
-        "link": "https://myrspace.com/api/v1/export/export123.zip"
-        }]
-    }
-    
- The enclosure link can then be used to access the download:
+```bash
+{
+  "id": 23,
+  "status": "COMPLETED",
+  "result": {
+    "checksum": "abcde12345",
+    "algorithm": "CRC32",
+    "size": 1024,
+    "expiryDate": "2017-11-25T00:00:00.000Z"
+   },
+  "_links": [{
+    "rel": "enclosure",
+    "link": "https://REPLACE.researchspace.com/api/v1/export/export123.zip"
+    }]
+}
+```
 
-    curl -v -H "apiKey: <APIKEY>"  -H "accept: application/octet-stream" "<RSPACE_URL>/api/v1/export/export123.zip"
+The enclosure link can then be used to access the download:
+
+```bash
+curl -v -H "apiKey: <APIKEY>" -H "accept: application/octet-stream" "<RSPACE_URL>/api/v1/export/export123.zip"
+```

--- a/oauth.md
+++ b/oauth.md
@@ -69,9 +69,14 @@ curl -X POST -Fgrant_type="password" -Fclient_id="$CLIENT_ID" \
  -Fpassword="$PASSWORD" -Fis_jwt="true" "$RSPACE_URL/oauth/token"
 ```
 
-You can generate as many JWT tokens as you like - all of them will be valid until expiry, and until the refresh token is not updated.
+You can generate as many JWT tokens as you like.
+All JWT tokens will be valid until expiry, and until the refresh token is not updated.
 
-JWT tokens have been implemented in a way that does not interfere with the normal access and refresh token generation workflow. Hence if a JWT is requested for an already existing access/refresh token pair, assume the unhashed refresh token is known and do not return in in the response body. In addition, grant type of `refresh_token` with `is_jwt` parameter will return a new JWT token, but will not update the refresh token.
+JWT tokens do not interfere with the normal access/refresh token generation workflow.
+If a JWT is requested for an existing access/refresh token pair, the RSpace API assumes
+the refresh token is known and does not return it in the response body. In addition,
+grant type of `refresh_token` with `is_jwt` parameter will return a new JWT token,
+but will not update the refresh token.
 
 ## Making API calls
 

--- a/oauth.md
+++ b/oauth.md
@@ -22,15 +22,15 @@ This follows standard OAuth 'password' grant flow.
 To acquire a token:
 
 ```bash
-export username="username"
-export rspacepwd="password"
-export client_id="id"
-export client_secret="secret"
-export RSPACE_URL=https://myrspace.com
+export USERNAME="username"
+export PASSWORD="password"
+export CLIENT_ID="id"
+export CLIENT_SECRET="secret"
+export RSPACE_URL=https://REPLACE.researchspace.com
 
-curl -X POST -Fgrant_type="password" -Fclient_id="$client_id" \
- -Fclient_secret="$client_secret" -Fusername="$username" \
- -password="$rspacepwd" "$RSPACE_URL/oauth/token"
+curl -X POST -Fgrant_type="password" -Fclient_id="$CLIENT_ID" \
+ -Fclient_secret="$CLIENT_SECRET" -Fusername="$USERNAME" \
+ -Fpassword="$PASSWORD" "$RSPACE_URL/oauth/token"
 ```
 
 This call will return the access token, refresh tokens and a duration, in seconds, for the validity of the access token:
@@ -51,20 +51,34 @@ You can invoke this request as many times as you like - only 1 access token is e
 Using example data from the above:
 
 ```bash
-export refresh_token=rTdb7EMWXdCCdzZzMLD+EWcoXATmETll
+export REFRESH_TOKEN=rTdb7EMWXdCCdzZzMLD+EWcoXATmETll
 
-curl -X POST -Fgrant_type="refresh_token" -Fclient_id="$client_id" \
- -Fclient_secret="$client_secret" -Frefresh_token="$refresh_token" "$RSPACE_URL/oauth/token"
+curl -X POST -Fgrant_type="refresh_token" -Fclient_id="$CLIENT_ID" \
+ -Fclient_secret="$CLIENT_SECRET" -Frefresh_token="$REFRESH_TOKEN" "$RSPACE_URL/oauth/token"
  ```
 
-will return a new refresh token and access token.
+Will return a new refresh token and access token.
+
+## JWT tokens
+
+We also support JWT token generation. To obtain a JWT token, add `-Fis_jwt="true"` to `password` or `refresh_token` grant types.
+
+```bash
+curl -X POST -Fgrant_type="password" -Fclient_id="$CLIENT_ID" \
+ -Fclient_secret="$CLIENT_SECRET" -Fusername="$USERNAME" \
+ -Fpassword="$PASSWORD" -Fis_jwt="true" "$RSPACE_URL/oauth/token"
+```
+
+You can generate as many JWT tokens as you like - all of them will be valid until expiry, and until the refresh token is not updated.
+
+JWT tokens have been implemented in a way that does not interfere with the normal access and refresh token generation workflow. Hence if a JWT is requested for an already existing access/refresh token pair, assume the unhashed refresh token is known and do not return in in the response body. In addition, grant type of `refresh_token` with `is_jwt` parameter will return a new JWT token, but will not update the refresh token.
 
 ## Making API calls
 
 Use your access token as follows to make API calls.
 
 ```bash
-export access_token=TuWHW0+8mUauD/y9E0HklZqrHGkA6+34
+export ACCESS_TOKEN=TuWHW0+8mUauD/y9E0HklZqrHGkA6+34
 ## for example, list your documents
-curl -H"Authorization: Bearer $access_token" "$RSPACE_URL/api/v1/documents"
+curl -H"Authorization: Bearer $ACCESS_TOKEN" "$RSPACE_URL/api/v1/documents"
 ```

--- a/sharing.md
+++ b/sharing.md
@@ -1,8 +1,10 @@
+# Sharing of notebooks and documents
+
 From RSpace 1.56 (API version 1.5) you can programmatically share notebooks and documents.
 
 ## Background
 
-###  What can be shared?
+### What can be shared?
 
 * One or more documents or notebooks can be shared.
 * Only items belonging to the authenticated user can be shared. Just like in the web application, users can't share other peoples' work.
@@ -11,7 +13,6 @@ From RSpace 1.56 (API version 1.5) you can programmatically share notebooks and 
 
 * Items can be shared with one or more groups that the authenticated user belongs to.
 * Items can be shared with one or more individual users in groups that the authenticated user belongs to.
-
 
 ## Sharing
 
@@ -22,30 +23,33 @@ Before sending a SHARE operation, you must determine:
 * The IDs of the items you want to share. You can get these IDs from the /documents GET method, either listing or searching.
 * The IDs of the users/groups you want to share with. You can get these from the /groups GET endpoint, e.g.
 
-    curl -X GET "<RSPACE_URL>/api/v1/groups" \
-    -H "accept: application/json" -H "apiKey: <APIKEY>"
-       
+```bash
+curl -X GET "<RSPACE_URL>/api/v1/groups" \
+-H "accept: application/json" -H "apiKey: <APIKEY>"
+```
+
 which will return a listing of group information. An example listing is in [groupsListing.json](tutorial-data/sharingContent/groupsListing.json)
 
 As well as the IDs of users and groups, the `sharedFolderId` property is also useful if you want to create new shared folders to
- share the content into.
- 
- Here's an example where we use the popular [jq](https://stedolan.github.io/jq/tutorial/) tool to parse out the information we want that is relevant to sharing.
- 
- 
-    curl -X GET "<RSPACE_URL>/api/v1/groups" \
-       -H "accept: application/json" -H "apiKey: <APIKEY>" \
-    | jq '[.[] | {groupId: .id, folderId: .sharedFolderId}]'
-    
+share the content into.
+
+Here's an example where we use the popular [jq](https://stedolan.github.io/jq/tutorial/) tool to parse out the information we want that is relevant to sharing.
+
+```bash
+curl -X GET "<RSPACE_URL>/api/v1/groups" \
+   -H "accept: application/json" -H "apiKey: <APIKEY>" \
+| jq '[.[] | {groupId: .id, folderId: .sharedFolderId}]'
+```
+
 ### Submitting a share request
 
- Once we have identified what we want to share, and who with, we can create the body of the request. An example is in [sharePost.json](tutorial-data/sharingContent/sharePost.json), which shows how to share 2 items with 2 groups and a user, with varying permissions.
- 
- At least one user or group must be specified, and at least one item to share. If no folder ID is set, and no permission, then the default is that the item will be shared with `READ` permission into the top-level shared folder of the group.
- 
- Here is an example of the minimal request body required to share 1 item with a group:
- 
-``` 
+Once we have identified what we want to share, and who with, we can create the body of the request. An example is in [sharePost.json](tutorial-data/sharingContent/sharePost.json), which shows how to share 2 items with 2 groups and a user, with varying permissions.
+
+At least one user or group must be specified, and at least one item to share. If no folder ID is set, and no permission, then the default is that the item will be shared with `READ` permission into the top-level shared folder of the group.
+
+Here is an example of the minimal request body required to share 1 item with a group:
+
+```json
 {
   "itemsToShare": [
      1234
@@ -58,13 +62,14 @@ As well as the IDs of users and groups, the `sharedFolderId` property is also us
   "users": []
 }
 ```
- It will be shared with READ permission into the top level of the group folder.
- 
- The response is a `ShareInfo` object summarising a successful share action. Here is an example of the response that 
+
+It will be shared with READ permission into the top level of the group folder.
+
+The response is a `ShareInfo` object summarising a successful share action. Here is an example of the response that
 might be generated from the simple request body above:
- 
- ```
- {
+
+```json
+{
   "shareInfos": [
     {
       "id": 6789,
@@ -77,29 +82,32 @@ might be generated from the simple request body above:
 }
 ```
 
-Any items that could not be shared are added to the `failedShareIds` list. 
+Any items that could not be shared are added to the `failedShareIds` list.
 
 ### Unsharing
 
 Unsharing is accomplished by a `DELETE` request, using the ID of the Share object to identify what should be unshared.
 In the above example, the share ID is '6789', so we would use this in the path of the delete request:
 
-    curl -v  -X DELETE  -H "apiKey: <APIKEY>"\
-      "<RSPACE_URL>/api/v1/share/6789" 
-      
- will unshare document with id '1234' from group '12345'.
- 
- Successful deletion will return a 204 HTTP status code
- 
+```bash
+curl -v  -X DELETE  -H "apiKey: <APIKEY>"\
+  "<RSPACE_URL>/api/v1/share/6789"
+```
+
+will unshare document with id '1234' from group '12345'.
+
+Successful deletion will return a 204 HTTP status code
+
 ### Listing shared items
 
 It's possible to list shared items, giving similar information to that obtained from MyRSpace -> Shared Documents page.
 
-This is a paginated and searchable method, e.g. 
+This is a paginated and searchable method, e.g.
 
-    curl -X GET "<RSPACE_URL>/api/v1/share?pageSize=20&orderBy=name%20desc" \
-    -H "accept: application/json" -H "apiKey: <APIKEY>"
-    
- This will return a list of `ShareInfo` objects. Additionally as with all paginated listings, the `_links` attribute will contain
-  links to previous/next pages.
- 
+```bash
+curl -X GET "<RSPACE_URL>/api/v1/share?pageSize=20&orderBy=name%20desc" \
+-H "accept: application/json" -H "apiKey: <APIKEY>"
+```
+
+This will return a list of `ShareInfo` objects. Additionally as with all paginated listings, the `_links` attribute will contain
+links to previous/next pages.


### PR DESCRIPTION
- Documentation improvements and documentation for the newly added JWT functionality
- Security fix: `https://myrspace.com` exists, if someone copies and pastes documentation example without changing the `RSPACE_URL` they could be sending their username and password to `myrspace.com` instead of any of the RSpace servers.
- Formatting improvements for the whole project, if only JWT documentation changes are desired, please view this commit: https://github.com/rspace-os/api-tutorial/pull/3/commits/5f4ec8241621628b89ca39cc90194ed6b6f39848